### PR TITLE
Increase retries of sync operations and increase wait between attempts.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ CLOUDSMITH_REPO="${2}"
 CLOUDSMITH_USERNAME="${3}"
 export CLOUDSMITH_API_KEY="${4}"
 
+cloudsmith_push_args=(--sync-attempts 10 --wait-interval 5 --republish)
+
 # required to make python 3 work with cloudsmith script
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
@@ -22,11 +24,11 @@ function upload_rpm {
     pkg_rel=$(echo "${rev_filename}" | cut -d '.' -f3 | rev)
     release_ver="${pkg_rel:2}"
 
-    cloudsmith push rpm --republish "${CLOUDSMITH_REPO}/${distro}/${release_ver}" "${1}"
+    cloudsmith push rpm "${cloudsmith_push_args[@]}" "${CLOUDSMITH_REPO}/${distro}/${release_ver}" "${1}"
 }
 
 function upload_deb {
-    cloudsmith push deb --republish "${CLOUDSMITH_REPO}/${2}/${3}" "${1}"
+    cloudsmith push deb "${cloudsmith_push_args[@]}" "${CLOUDSMITH_REPO}/${2}/${3}" "${1}"
 }
 
 function cloudsmith_upload {


### PR DESCRIPTION
Make package publishing more reliable when there are a lot of packages to upload.

Should avoid this issue which occurs sporadically:

```
Requested was throttled (429): Retrying after 1 second(s) ... 

Requested was throttled (429): Retrying after 1 second(s) ... 

Requested was throttled (429): Retrying after 1 second(s) ... 

Requested was throttled (429): Retrying after 1 second(s) ... 

Requested was throttled (429): Retrying after 1 second(s) ... 

Requested was throttled (429): Retrying after 1 second(s) ... 
ERROR
Failed to synchronise file! (status: 429 - Too Many Requests)

Detail: Request was throttled. Expected available in 1 second.
```