### PR TITLE
Upload rocky and alma packages to the "el" distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get -y install curl git python3-pip
+RUN apt-get update && apt-get -y install curl git python3-pip pipx
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,12 +64,12 @@ function cloudsmith_upload {
 
     releasemajor=`echo ${release} | cut -d "." -f 1`
 
-    echo "${distro} ${release}"
-
     if [[ ${distro} =~ centos ]]; then
         upload_rpm "centos" "${release}" "${pkg_fullpath}"
     elif [[ ${distro} =~ fedora ]]; then
         upload_rpm "fedora" "${release}" "${pkg_fullpath}"
+    elif [[ ${distro} =~ el ]]; then
+        upload_rpm "el" "${releasemajor}" "${pkg_fullpath}"
     elif [[ ${distro} =~ rocky ]]; then
         upload_rpm "el" "${releasemajor}" "${pkg_fullpath}"
     elif [[ ${distro} =~ alma ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,14 +62,16 @@ function cloudsmith_upload {
     release=$2
     pkg_fullpath=$3
 
+    releasemajor=`echo ${release} | cut -d "." -f 1`
+
     if [[ ${distro} =~ centos ]]; then
         upload_rpm "centos" "${release}" "${pkg_fullpath}"
     elif [[ ${distro} =~ fedora ]]; then
         upload_rpm "fedora" "${release}" "${pkg_fullpath}"
     elif [[ ${distro} =~ rocky ]]; then
-        upload_rpm "rocky" "${release}" "${pkg_fullpath}"
+        upload_rpm "el" "${releasemajor}" "${pkg_fullpath}"
     elif [[ ${distro} =~ alma ]]; then
-        upload_rpm "almalinux" "${release}" "${pkg_fullpath}"
+        upload_rpm "el" "${releasemajor}" "${pkg_fullpath}"
     else
         upload_deb "${distro}" "${release}" "${pkg_fullpath}"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ function cloudsmith_upload {
     fi
 }
 
-pip3 install --user --upgrade cloudsmith-cli
+pipx upgrade cloudsmith-cli
 
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ function cloudsmith_upload {
     fi
 }
 
-pipx upgrade cloudsmith-cli
+pipx install cloudsmith-cli
 
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,8 +79,9 @@ function cloudsmith_upload {
     fi
 }
 
-pip3 install --upgrade cloudsmith-cli
+pip3 install --user --upgrade cloudsmith-cli
 
+export PATH="$HOME/.local/bin:$PATH"
 
 while IFS= read -r -d '' path; do
     IFS=_ read -r distro release <<< "$(basename "${path}")"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,8 @@ function cloudsmith_upload {
 
     releasemajor=`echo ${release} | cut -d "." -f 1`
 
+    echo "${distro} ${release}"
+
     if [[ ${distro} =~ centos ]]; then
         upload_rpm "centos" "${release}" "${pkg_fullpath}"
     elif [[ ${distro} =~ fedora ]]; then


### PR DESCRIPTION
Cloudsmith now treats rocky and alma the same as any other RHEL package, so they can all be uploaded using the `el` distribution and used interchangeably, rather than requiring separate packages for each RHEL derivative.